### PR TITLE
Replace REPLACE INTO with INSERT INTO.

### DIFF
--- a/weave_storage.php
+++ b/weave_storage.php
@@ -220,8 +220,12 @@ class WeaveStorage
 
         try
         {
-            $insert_stmt = 'replace into wbo (username, id, collection, parentid, predecessorid, sortindex, modified, payload, payload_size)
-                values (:username, :id, :collection, :parentid, :predecessorid, :sortindex, :modified, :payload, :payload_size)';
+            $insert_stmt = 'insert into wbo (username, id, collection, parentid, predecessorid, sortindex, modified, payload, payload_size) 
+                            values (:username, :id, :collection, :parentid, :predecessorid, :sortindex, :modified, :payload, :payload_size) 
+                            on duplicate key update 
+                            username=values(username), id=values(id), collection=values(collection), parentid=values(parentid), 
+                            predecessorid=values(predecessorid), sortindex=values(sortindex), modified=values(modified), payload=values(payload), 
+                            payload_size=values(payload_size)';
             $sth = $this->_dbh->prepare($insert_stmt);
 
             $username = $this->_username;


### PR DESCRIPTION
The previously-used `replace into` SQL statement is extremely inefficient on InnoDB (it removes a row, updates indices, and inserts a new row, updating indices again -- it doesn't actually update the row data). I've made this change on my production server, bringing down the I/O overhead tremendously. This change would be needed on any slightly larger deployments when using InnoDB (and other engines that would get large overhead from `replace into` statements). The statement is functionally completely equivalent to the old one.
